### PR TITLE
needed to update a transactions hash after signing the transaction 

### DIFF
--- a/src/node/node.go
+++ b/src/node/node.go
@@ -36,10 +36,10 @@ type Node struct {
 	Killed bool //So the node knows to kill itself
 
 	Peer_completions []*Completed
-	Index int
-	Name string
-	PortNum string
-	PeerPorts []string
+	Index            int
+	Name             string
+	PortNum          string
+	PeerPorts        []string
 }
 
 //Structs for RPC calls. Right now they only have block.
@@ -246,8 +246,9 @@ func (n *Node) Create_transaction() {
 	input = strings.Replace(input, "\n", "", -1)
 
 	t := structures.CreateTransaction(input, authorID)
-        privKey := n.Privkey
-        t.Signature = structures.SignTransaction_withoutFile(t, &privKey)
+	privKey := n.Privkey
+	t.Signature = structures.SignTransaction_withoutFile(t, &privKey)
+	t.UpdateTransactionHash()
 	//t.Signature = structures.SignTransaction(t)
 	if n.Cur_block.MTree == nil {
 		var transactions []structures.Transaction
@@ -298,7 +299,7 @@ func (n *Node) Print_chain() {
 }
 
 func (n *Node) Print_posts() {
-        fmt.Println("--------------------------------------------------------------------------------")
+	fmt.Println("--------------------------------------------------------------------------------")
 	totalTrans := 0
 	for _, block := range n.Chain {
 		//find a way to get transactions in order from the merkle tree
@@ -315,10 +316,9 @@ func (n *Node) Print_posts() {
 	}
 
 	fmt.Printf("Number of Transactions %d\n", totalTrans)
-        fmt.Println("--------------------------------------------------------------------------------")
+	fmt.Println("--------------------------------------------------------------------------------")
 
 }
-
 
 func (n *Node) Print_peer_completions() {
 	for _, V := range n.Peer_completions {
@@ -328,9 +328,10 @@ func (n *Node) Print_peer_completions() {
 
 //goroutine to create a transaction from a string instead
 //of taking user input.
-func (n *Node) Create_transaction_from_input(input string){
+func (n *Node) Create_transaction_from_input(input string) {
 	t := structures.CreateTransaction(input, 0)
 	t.Signature = structures.SignTransaction_withoutFile(t, &n.Privkey)
+	t.UpdateTransactionHash()
 	if n.Cur_block.MTree == nil {
 		var transactions []structures.Transaction
 		transactions = append(transactions, *t)

--- a/src/structures/transaction.go
+++ b/src/structures/transaction.go
@@ -22,7 +22,7 @@ type Transaction struct {
 	//int is just a placeholder for now
 
 	Signature []byte
-	publicKey  rsa.PublicKey
+	publicKey rsa.PublicKey
 	//need to send it somewhere
 }
 
@@ -37,8 +37,8 @@ func SignTransaction_withoutFile(transaction *Transaction, privKey *rsa.PrivateK
 //returns a signature, which is the signed serialization of the transaction
 func SignTransaction(transaction *Transaction) []byte {
 	privKey, pubKey := keys.GetKeys()
-        fmt.Println(pubKey)
-        fmt.Println(privKey)
+	fmt.Println(pubKey)
+	fmt.Println(privKey)
 	transaction.publicKey = *pubKey
 
 	transactionBytes := transaction.Serialize()
@@ -75,6 +75,12 @@ func CreateTransaction(text string, author int) *Transaction {
 	return &t
 }
 
+func (t Transaction) UpdateTransactionHash() *Transaction {
+	hash := t.Serialize()
+	t.ID = hash[:]
+	return &t
+}
+
 func (t Transaction) Serialize() []byte {
 	//don't want to serialize the signature
 	tmp_signature := t.Signature
@@ -99,13 +105,12 @@ func Deserialize(serialized []byte) *Transaction {
 	return &result
 }
 
-
 func (t *Transaction) To_string() string {
-    //Must be desirialized before calling this
-    var result string
+	//Must be desirialized before calling this
+	var result string
 
-    result += fmt.Sprintf("Author: %x\n", t.publicKey)
-    result += fmt.Sprintf("Post:\n      %v\n", t.Text)
+	result += fmt.Sprintf("Author: %x\n", t.publicKey)
+	result += fmt.Sprintf("Post:\n      %v\n", t.Text)
 
-    return result
+	return result
 }


### PR DESCRIPTION
If the transactions hash is not updated after signing the transaction then the transactions signature will be lost when gob encoded into the Merkle tree, and the decoded out of the tree again.